### PR TITLE
Add room to talk details view

### DIFF
--- a/Mixit/Network/TalkResource.swift
+++ b/Mixit/Network/TalkResource.swift
@@ -26,6 +26,17 @@ struct TalkResponse: Codable {
     // let photoUrls
     let slug: String
     let id: String
+	
+	static let humanReadableRoomNames = [
+		"AMPHI1": "Amphithéâtre Hamilton",
+		"AMPHI2": "Amphithéâtre Lovelace",
+		"ROOM1": "Salle Gosling (F08)",
+		"ROOM2": "Salle Kare (F02/03)",
+		"ROOM3": "Salle Turing (F06)",
+		"ROOM4": "Salle Nonaka (F07)",
+		"ROOM5": "Salle Dijkstra (F05)",
+		"TWITCH": "Twitch.tv"
+	]
 }
 
 extension NSManagedObjectContext {

--- a/Mixit/View/TalkDetail.swift
+++ b/Mixit/View/TalkDetail.swift
@@ -72,6 +72,18 @@ struct TalkDetail: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
                     Spacer(minLength: 6)
                 }
+				if
+					let room = talk.room
+				{
+					let formattedRoom = TalkResponse.humanReadableRoomNames[room] ?? room
+					
+					HStack {
+						Image(systemName: "mappin.and.ellipse")
+						Text(formattedRoom)
+					}
+					.frame(maxWidth: .infinity, alignment: .leading)
+					Spacer(minLength: 6)
+				}
                 HStack {
                     Image(systemName: "clock")
                     if let startDate = talk.startDate, let endDate = talk.endDate {
@@ -206,6 +218,7 @@ struct TalkDetail_Previews: PreviewProvider {
         talk.title = "First Talk"
         talk.language = "fr"
         talk.format = "Keynote"
+		talk.room = "AMPHI2"
         talk.startDate = Date()
         talk.endDate = Date().addingTimeInterval(3600)
         talk.desc = "Bla bla bla... Bla bla bla... Bla bla bla..."


### PR DESCRIPTION
Adds the talk's room, if any, to the talk details view.
The API only seems to return room identifiers, not actual room names; in the interest of speed, the mapping is currently hard-coded in `TalkResponse.humanReadableRoomNames`.

<img width="511" alt="" src="https://user-images.githubusercontent.com/2979318/231479198-942f6fd6-677f-48f1-a617-b2445d03c847.png">

