### PR TITLE
Update talk detail design

### DIFF
--- a/Mixit.xcodeproj/project.pbxproj
+++ b/Mixit.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		BB199B1F29E9ECBD0066E5F8 /* Rooms.strings in Resources */ = {isa = PBXBuildFile; fileRef = BB199B2129E9ECBD0066E5F8 /* Rooms.strings */; };
 		BBE442BF2D67C8D000BD17F6 /* TalkDetailItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBE442BE2D67C8D000BD17F6 /* TalkDetailItem.swift */; };
 		BBE442C02D67C8D000BD17F6 /* TalkDetailItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBE442BE2D67C8D000BD17F6 /* TalkDetailItem.swift */; };
+		BBE442C22D6A6AA400BD17F6 /* SpeakerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBE442C12D6A6A9F00BD17F6 /* SpeakerView.swift */; };
+		BBE442C32D6A6AA400BD17F6 /* SpeakerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBE442C12D6A6A9F00BD17F6 /* SpeakerView.swift */; };
 		D7207A30289BEF9300D36F4A /* TalkDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7207A2F289BEF9300D36F4A /* TalkDetail.swift */; };
 		D7207A31289BEF9300D36F4A /* TalkDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7207A2F289BEF9300D36F4A /* TalkDetail.swift */; };
 		D7207A33289CFC6500D36F4A /* MixitClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7207A32289CFC6500D36F4A /* MixitClient.swift */; };
@@ -54,6 +56,7 @@
 		BB415B4029DB600B0056A8EF /* Mixit-iOS-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Mixit-iOS-Info.plist"; sourceTree = "<group>"; };
 		BB415B4129DB600F0056A8EF /* Mixit-macOS-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Mixit-macOS-Info.plist"; sourceTree = "<group>"; };
 		BBE442BE2D67C8D000BD17F6 /* TalkDetailItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TalkDetailItem.swift; sourceTree = "<group>"; };
+		BBE442C12D6A6A9F00BD17F6 /* SpeakerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeakerView.swift; sourceTree = "<group>"; };
 		D7207A2F289BEF9300D36F4A /* TalkDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TalkDetail.swift; sourceTree = "<group>"; };
 		D7207A32289CFC6500D36F4A /* MixitClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixitClient.swift; sourceTree = "<group>"; };
 		D7207A36289CFDC000D36F4A /* TalkResource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TalkResource.swift; sourceTree = "<group>"; };
@@ -171,6 +174,7 @@
 				D7683FBA289BE75C0000F388 /* ContentView.swift */,
 				D7683FE1289BECE20000F388 /* TalkRow.swift */,
 				D7207A2F289BEF9300D36F4A /* TalkDetail.swift */,
+				BBE442C12D6A6A9F00BD17F6 /* SpeakerView.swift */,
 				BBE442BE2D67C8D000BD17F6 /* TalkDetailItem.swift */,
 				D7207A42289D634600D36F4A /* InfoView.swift */,
 				D78BC6DE2BA32DC900ED9104 /* AddEventController.swift */,
@@ -240,7 +244,7 @@
 					};
 				};
 			};
-			buildConfigurationList = 1FA55BC21911A5D2000260B3 /* Build configuration list for PBXProject "mixit" */;
+			buildConfigurationList = 1FA55BC21911A5D2000260B3 /* Build configuration list for PBXProject "Mixit" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
@@ -292,6 +296,7 @@
 			files = (
 				D78BC6DF2BA32DC900ED9104 /* AddEventController.swift in Sources */,
 				D7207A30289BEF9300D36F4A /* TalkDetail.swift in Sources */,
+				BBE442C32D6A6AA400BD17F6 /* SpeakerView.swift in Sources */,
 				D7207A3A289D32A800D36F4A /* MemberHelpers.swift in Sources */,
 				D7683FCF289BE75D0000F388 /* Persistence.swift in Sources */,
 				D7683FDE289BEC3C0000F388 /* TalkHelpers.swift in Sources */,
@@ -312,6 +317,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BBE442C22D6A6AA400BD17F6 /* SpeakerView.swift in Sources */,
 				D7207A31289BEF9300D36F4A /* TalkDetail.swift in Sources */,
 				D7207A3B289D32A800D36F4A /* MemberHelpers.swift in Sources */,
 				D7683FD0289BE75D0000F388 /* Persistence.swift in Sources */,
@@ -644,7 +650,7 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		1FA55BC21911A5D2000260B3 /* Build configuration list for PBXProject "mixit" */ = {
+		1FA55BC21911A5D2000260B3 /* Build configuration list for PBXProject "Mixit" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				1FA55BF71911A5D4000260B3 /* Debug */,

--- a/Mixit/Model/TalkHelpers.swift
+++ b/Mixit/Model/TalkHelpers.swift
@@ -149,6 +149,9 @@ extension Talk {
 
 extension String {
     func cleaned() -> String {
-        return replacingOccurrences(of: "&#39;", with: "’").replacingOccurrences(of: "&#34;", with: "\"")
+        return
+            replacingOccurrences(of: "&#39;", with: "'")
+            .replacingOccurrences(of: "&#34;", with: "\"")
+            .replacingOccurrences(of: "&amp;", with: "&")
     }
 }

--- a/Mixit/Model/TalkHelpers.swift
+++ b/Mixit/Model/TalkHelpers.swift
@@ -95,6 +95,23 @@ extension Talk {
         }
     }
 
+    var localizedLanguage: String? {
+        get {
+            guard let language else {
+                return nil
+            }
+
+            if language == "fr" || language == "FRENCH" {
+                return NSLocalizedString("French", comment: "")
+            }
+            else if language == "en" || language == "ENGLISH" {
+                return NSLocalizedString("English", comment: "")
+            }
+
+            return nil
+        }
+    }
+
     func fetchSpeakers() -> [Member] {
         guard let speakersIdentifiers else {
             return []

--- a/Mixit/Model/TalkHelpers.swift
+++ b/Mixit/Model/TalkHelpers.swift
@@ -36,6 +36,29 @@ extension Talk {
         }
     }
 
+    /// The description if available, or the summary otherwise.
+    var effectiveDescription: String? {
+        guard let desc, desc != "" else {
+            return summary
+        }
+
+        return desc
+    }
+
+    /// The summary if the description is available, otherwise nothing.
+    var effectiveSummary: String? {
+        guard let desc, desc != "" else {
+            return nil
+        }
+
+        return summary
+    }
+
+    @objc
+    var shortestAvailableDescription: String? {
+        effectiveSummary ?? effectiveDescription
+    }
+
     func update(with talkResponse: TalkResponse) {
         desc = talkResponse.description.cleaned()
         format = talkResponse.format.replacingOccurrences(of: "_", with: " ")

--- a/Mixit/Model/TalkHelpers.swift
+++ b/Mixit/Model/TalkHelpers.swift
@@ -132,7 +132,13 @@ extension Talk {
     }
 
     var isFavorited: Bool {
-        return favorited?.boolValue ?? false
+        get {
+            return favorited?.boolValue ?? false
+        }
+
+        set {
+            favorited = NSNumber(booleanLiteral: newValue)
+        }
     }
 
     var isUpcomingTalk: Bool {

--- a/Mixit/View/ContentView.swift
+++ b/Mixit/View/ContentView.swift
@@ -13,6 +13,8 @@ struct ContentView: View {
     @Environment(\.managedObjectContext) private var viewContext
     @EnvironmentObject var client: MixitClient
 
+    let dateFormatter: DateIntervalFormatter = TalkRow.defaultDateFormatter()
+
     @State private var showingInfo = false
     @State private var searchText = ""
     static let yearPredicate = NSPredicate(format: "%K == %@", #keyPath(Talk.event), String(MixitClient.currentYear))
@@ -43,8 +45,6 @@ struct ContentView: View {
       predicate: yearPredicate
     ) var talks: SectionedFetchResults<String, Talk>
 
-    private var dateFormatter = DateFormatter()
-
     var body: some View {
         NavigationView {
             List {
@@ -54,7 +54,7 @@ struct ContentView: View {
                             NavigationLink {
                                 TalkDetail(talk: talk)
                             } label: {
-                                TalkRow(talk: talk)
+                                TalkRow(dateFormatter: dateFormatter, talk: talk)
                             }
                             .swipeActions {
                                 Button(talk.isFavorited ? "Remove from Favorites" : "Add to Favorites") {

--- a/Mixit/View/ContentView.swift
+++ b/Mixit/View/ContentView.swift
@@ -28,7 +28,11 @@ struct ContentView: View {
         }
 
         talks.nsPredicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
-            NSPredicate(format: "%K contains[cd] %@ OR %K contains[cd] %@", #keyPath(Talk.title), newValue, #keyPath(Talk.shortestAvailableDescription), newValue),
+            NSCompoundPredicate(orPredicateWithSubpredicates: [
+                NSPredicate(format: "%K contains[cd] %@", #keyPath(Talk.title), newValue),
+                NSPredicate(format: "%K contains[cd] %@", #keyPath(Talk.summary), newValue),
+                NSPredicate(format: "%K contains[cd] %@", #keyPath(Talk.desc), newValue)
+            ]),
             ContentView.yearPredicate])
       }
     }

--- a/Mixit/View/ContentView.swift
+++ b/Mixit/View/ContentView.swift
@@ -28,7 +28,7 @@ struct ContentView: View {
         }
 
         talks.nsPredicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
-            NSPredicate(format: "%K contains[cd] %@ OR %K contains[cd] %@", #keyPath(Talk.title), newValue, #keyPath(Talk.summary), newValue),
+            NSPredicate(format: "%K contains[cd] %@ OR %K contains[cd] %@", #keyPath(Talk.title), newValue, #keyPath(Talk.shortestAvailableDescription), newValue),
             ContentView.yearPredicate])
       }
     }

--- a/Mixit/View/ContentView.swift
+++ b/Mixit/View/ContentView.swift
@@ -75,6 +75,13 @@ struct ContentView: View {
             .listStyle(.plain)
 #endif
             .navigationTitle("MiXiT Schedule")
+            .overlay {
+                if #available(iOS 17, macOS 14, *) {
+                    if talks.isEmpty && !searchText.isEmpty {
+                        ContentUnavailableView.search
+                    }
+                }
+            }
             .toolbar {
                 ToolbarItem {
                     Button(action: {

--- a/Mixit/View/SpeakerView.swift
+++ b/Mixit/View/SpeakerView.swift
@@ -1,0 +1,71 @@
+//
+//  SpeakerView.swift
+//  Mixit
+//
+//  Created by Vincent Tourraine on 22/02/2025.
+//  Copyright © 2025 Studio AMANgA. All rights reserved.
+//
+
+import SwiftUI
+
+struct SpeakerView: View {
+    let nameFormatter: PersonNameComponentsFormatter
+
+    @ObservedObject var speaker: Member
+
+    var body: some View {
+        HStack(alignment: .top) {
+            // Speaker photo
+            if let photoURL = speaker.photoURLString {
+                AsyncImage(url: URL(string: photoURL)) { image in
+                    image
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                        .clipShape(Circle())
+                } placeholder: {
+                    Image(systemName: "person.crop.circle")
+                        .resizable()
+                }
+                .frame(width: 38, height: 38)
+            }
+            else {
+                Image(systemName: "person.crop.circle")
+                    .resizable()
+                    .frame(width: 38, height: 38)
+            }
+
+            // Speaker info
+            VStack(alignment: .leading) {
+                Text(nameFormatter.string(from: PersonNameComponents(givenName: speaker.firstName, familyName: speaker.lastName)))
+                    .font(.subheadline)
+
+                if let company = speaker.company {
+                    Text(company)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .frame(minHeight: 38)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+struct SpeakerView_Previews: PreviewProvider {
+    static let inMemory = PersistenceController(inMemory: true)
+    static let speaker: Member = {
+        let speaker = Member(context: inMemory.container.viewContext)
+        speaker.login = "1"
+        speaker.firstName = "John"
+        speaker.lastName = "Doe"
+        speaker.company = "MegaCorp"
+        speaker.photoURLString = "https://avatars.githubusercontent.com/u/886053?v=4"
+        return speaker
+    }()
+
+    static var previews: some View {
+        Group {
+            SpeakerView(nameFormatter: PersonNameComponentsFormatter(), speaker: speaker)
+        }
+    }
+}

--- a/Mixit/View/TalkDetail.swift
+++ b/Mixit/View/TalkDetail.swift
@@ -74,40 +74,7 @@ struct TalkDetail: View {
                 Spacer(minLength: 20)
 
                 ForEach(talk.fetchSpeakers()) { speaker in
-                    HStack(alignment: .top) {
-                        // Speaker photo
-                        if let photoURL = speaker.photoURLString {
-                            AsyncImage(url: URL(string: photoURL)) { image in
-                                image
-                                    .resizable()
-                                    .aspectRatio(contentMode: .fill)
-                                    .clipShape(Circle())
-                            } placeholder: {
-                                Image(systemName: "person.crop.circle")
-                                    .resizable()
-                            }
-                            .frame(width: 38, height: 38)
-                        }
-                        else {
-                            Image(systemName: "person.crop.circle")
-                                .resizable()
-                                .frame(width: 38, height: 38)
-                        }
-
-                        // Speaker info
-                        VStack(alignment: .leading) {
-                            Text(nameFormatter.string(from: PersonNameComponents(givenName: speaker.firstName, familyName: speaker.lastName)))
-                                .font(.subheadline)
-
-                            if let company = speaker.company {
-                                Text(company)
-                                    .font(.subheadline).foregroundStyle(.secondary)
-                            }
-                        }
-                        .frame(minHeight: 38)
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
-
+                    SpeakerView(nameFormatter: nameFormatter, speaker: speaker)
                     Spacer(minLength: 20)
                 }
 

--- a/Mixit/View/TalkDetail.swift
+++ b/Mixit/View/TalkDetail.swift
@@ -214,13 +214,25 @@ struct TalkDetail_Previews: PreviewProvider {
     static let talk: Talk = {
         let talk = Talk(context: inMemory.container.viewContext)
         talk.identifier = "1"
-        talk.title = "First Talk"
+        talk.title = "Au-delà des heures : La semaine de 4 jours comme levier d’égalité"
         talk.language = "fr"
-        talk.format = "Keynote"
+        talk.format = "Talk"
         talk.room = "AMPHI2"
         talk.startDate = Date()
         talk.endDate = Date().addingTimeInterval(3600)
-        talk.desc = "Bla bla bla... Bla bla bla... Bla bla bla..."
+        talk.summary =
+			"""
+			L’égalité…vaste sujet n’est ce pas ? 
+
+			Égalité salariale, reconnaissance équitable, évolution dans l’entreprise… Il est temps de briser les barrières de genre ! Allons même plus loin sur la diversité et l’inclusion en offrant une flexibilité accrue aux employé.es ayant des responsabilités familiales, des engagements ou des besoins particuliers.
+
+			Une révolution du travail se profile à l’horizon : la semaine de 4 jours. Un levier puissant pour l’égalité et je vais vous expliquer pourquoi.
+
+			Au cours de cette conférence, nous explorerons en détail les mécanismes par lesquels la semaine de 4 jours contribue à la diminution des inégalités au travail. Des exemples concrets s’appuyant sur des témoignages et des études de cas mettront en lumière les bienfaits de cette approche. 
+
+			Enfin, je vous donnerai les clés pour insuffler cette nouvelle façon de travailler dans votre propre structure. 
+			Saisissez l’opportunité d’initier des transformations positives dès maintenant !
+			"""
         return talk
     }()
 

--- a/Mixit/View/TalkDetail.swift
+++ b/Mixit/View/TalkDetail.swift
@@ -66,7 +66,9 @@ struct TalkDetail: View {
                         // Speaker photo
                         if let photoURL = speaker.photoURLString {
                             AsyncImage(url: URL(string: photoURL)) { image in
-                                image.resizable()
+                                image
+                                    .resizable()
+                                    .aspectRatio(contentMode: .fill)
                                     .clipShape(Circle())
                                     .overlay {
                                         Circle()

--- a/Mixit/View/TalkDetail.swift
+++ b/Mixit/View/TalkDetail.swift
@@ -61,6 +61,21 @@ struct TalkDetail: View {
                     Spacer(minLength: 20)
                 }
 
+                HStack {
+                    if let startDate = talk.startDate, let endDate = talk.endDate {
+                        TalkDetailItem(text: "\(Talk.dayFormatter.string(from: startDate).localizedCapitalized)\n\(timeIntervalFormatter.string(from: startDate, to: endDate))", systemImageName: "clock.circle.fill", imageColor: .blue)
+                    }
+                    if let room = talk.room {
+                        let formattedRoom = NSLocalizedString(room, tableName: "Rooms", comment: "")
+                        TalkDetailItem(text: formattedRoom, systemImageName: "mappin.circle.fill", imageColor: .red)
+                    }
+                    else {
+                        TalkDetailItem(text: "Not announced yet", systemImageName: "ellipsis.circle.fill", imageColor: .gray)
+                    }
+                }
+
+                Spacer(minLength: 20)
+
                 ForEach(talk.fetchSpeakers()) { speaker in
                     HStack(alignment: .top) {
                         // Speaker photo
@@ -111,19 +126,6 @@ struct TalkDetail: View {
 
                     Spacer(minLength: 20)
                 }
-
-				if let room = talk.room {
-					let formattedRoom = NSLocalizedString(room, tableName: "Rooms", comment: "")
-					TalkDetailItem(text: formattedRoom, systemImageName: "mappin.and.ellipse")
-				}
-                if let startDate = talk.startDate, let endDate = talk.endDate {
-                    TalkDetailItem(text: "\(Talk.dayFormatter.string(from: startDate).localizedCapitalized), \(timeIntervalFormatter.string(from: startDate, to: endDate))", systemImageName: "clock")
-                }
-                else {
-                    TalkDetailItem(text: "Not announced yet", systemImageName: "clock")
-                }
-
-                Spacer(minLength: 20)
 
                 if let effectiveSummary = talk.effectiveSummary {
                     Text(effectiveSummary)

--- a/Mixit/View/TalkDetail.swift
+++ b/Mixit/View/TalkDetail.swift
@@ -86,15 +86,15 @@ struct TalkDetail: View {
 
                 Spacer(minLength: 20)
 
-                if let summary = talk.summary {
-                    Text(summary)
+                if let effectiveSummary = talk.effectiveSummary {
+                    Text(effectiveSummary)
                         .font(.body).italic()
                         .frame(maxWidth: .infinity, alignment: .leading)
                     Spacer(minLength: 20)
                 }
 
-                if let desc = talk.desc {
-                    Text(desc)
+                if let effectiveDescription = talk.effectiveDescription {
+                    Text(effectiveDescription)
                         .font(.body)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }

--- a/Mixit/View/TalkDetail.swift
+++ b/Mixit/View/TalkDetail.swift
@@ -19,6 +19,8 @@ struct TalkDetail: View {
     @ObservedObject var talk: Talk
     @State var showAddEventModal = false
 
+    @Environment(\.colorScheme) private var colorScheme
+
     var shareItems: [Any] {
         get {
             if let title = talk.title, let year = talk.year,
@@ -60,33 +62,53 @@ struct TalkDetail: View {
                 }
 
                 ForEach(talk.fetchSpeakers()) { speaker in
-                    HStack {
+                    HStack(alignment: .top) {
+                        // Speaker photo
                         if let photoURL = speaker.photoURLString {
                             AsyncImage(url: URL(string: photoURL)) { image in
                                 image.resizable()
                                     .clipShape(Circle())
+                                    .overlay {
+                                        Circle()
+                                            .strokeBorder(
+                                                .primary.opacity(
+                                                    colorScheme == .light
+                                                    ? 0.1
+                                                    : 0.3
+                                                ),
+                                                lineWidth: 1
+                                            )
+                                    }
                             } placeholder: {
                                 Image(systemName: "person.crop.circle")
-                                    .font(.system(size: 32))
+                                    .resizable()
+                                    .font(.system(size: 10))
                             }
-                            .frame(width: 40, height: 40)
+                            .frame(width: 38, height: 38)
                         }
                         else {
                             Image(systemName: "person.crop.circle")
-                                .font(.system(size: 32))
-                                .frame(width: 40, height: 40)
+                                .resizable()
+                                .font(.system(size: 10))
+                                .frame(width: 38, height: 38)
                         }
+
+                        // Speaker info
                         VStack(alignment: .leading) {
                             Text(nameFormatter.string(from: PersonNameComponents(givenName: speaker.firstName, familyName: speaker.lastName)))
-                                .font(.body)
+                                .font(.subheadline.weight(.semibold))
+
                             if let company = speaker.company {
                                 Text(company)
-                                    .font(.body).italic()
+                                    .font(.subheadline).foregroundStyle(.secondary)
                             }
                         }
-                    }.frame(maxWidth: .infinity, alignment: .leading)
+                        .frame(minHeight: 38)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                    Spacer(minLength: 20)
                 }
-                Spacer(minLength: 20)
 
 				if let room = talk.room {
 					let formattedRoom = NSLocalizedString(room, tableName: "Rooms", comment: "")

--- a/Mixit/View/TalkDetail.swift
+++ b/Mixit/View/TalkDetail.swift
@@ -19,8 +19,6 @@ struct TalkDetail: View {
     @ObservedObject var talk: Talk
     @State var showAddEventModal = false
 
-    @Environment(\.colorScheme) private var colorScheme
-
     var shareItems: [Any] {
         get {
             if let title = talk.title, let year = talk.year,
@@ -38,24 +36,24 @@ struct TalkDetail: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading) {
-                Text(talk.title ?? "")
-                    .font(.largeTitle).fontWeight(.semibold)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                if let title = talk.title {
+                    Text(title)
+                        .font(.largeTitle)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
 
                 Spacer(minLength: 10)
 
-                if
-                    let language = talk.localizedLanguage,
-                    let format = talk.format
-                {
-
+                if let language = talk.localizedLanguage,
+                   let format = talk.format {
                     HStack(spacing: 0) {
                         Text(format.localizedCapitalized)
+                            .bold()
                         Text(" • ")
                         Text(language)
                     }
                     .foregroundStyle(.secondary)
-                    .font(.subheadline)
+                    .font(.body)
 
                     Spacer(minLength: 20)
                 }
@@ -84,35 +82,22 @@ struct TalkDetail: View {
                                     .resizable()
                                     .aspectRatio(contentMode: .fill)
                                     .clipShape(Circle())
-                                    .overlay {
-                                        Circle()
-                                            .strokeBorder(
-                                                .primary.opacity(
-                                                    colorScheme == .light
-                                                    ? 0.1
-                                                    : 0.3
-                                                ),
-                                                lineWidth: 1
-                                            )
-                                    }
                             } placeholder: {
                                 Image(systemName: "person.crop.circle")
                                     .resizable()
-                                    .font(.system(size: 10))
                             }
                             .frame(width: 38, height: 38)
                         }
                         else {
                             Image(systemName: "person.crop.circle")
                                 .resizable()
-                                .font(.system(size: 10))
                                 .frame(width: 38, height: 38)
                         }
 
                         // Speaker info
                         VStack(alignment: .leading) {
                             Text(nameFormatter.string(from: PersonNameComponents(givenName: speaker.firstName, familyName: speaker.lastName)))
-                                .font(.subheadline.weight(.semibold))
+                                .font(.subheadline)
 
                             if let company = speaker.company {
                                 Text(company)
@@ -252,14 +237,28 @@ struct SharingsPicker: NSViewRepresentable {
 struct TalkDetail_Previews: PreviewProvider {
     static let inMemory = PersistenceController(inMemory: true)
     static let talk: Talk = {
+        let speaker1 = Member(context: inMemory.container.viewContext)
+        speaker1.login = "1"
+        speaker1.firstName = "John"
+        speaker1.lastName = "Doe"
+        speaker1.company = "MegaCorp"
+        speaker1.photoURLString = "https://avatars.githubusercontent.com/u/886053?v=4"
+
+        let speaker2 = Member(context: inMemory.container.viewContext)
+        speaker2.login = "2"
+        speaker2.firstName = "Jane"
+        speaker2.lastName = ""
+        speaker2.company = ""
+
         let talk = Talk(context: inMemory.container.viewContext)
         talk.identifier = "1"
+        talk.speakersIdentifiers = speaker1.login! + Talk.serializationSeparator + speaker2.login!
         talk.title = "Au-delà des heures : La semaine de 4 jours comme levier d’égalité"
         talk.language = "fr"
         talk.format = "Talk"
         talk.room = "AMPHI2"
-        talk.startDate = Date()
-        talk.endDate = Date().addingTimeInterval(3600)
+        talk.startDate = Date.now
+        talk.endDate = Date(timeIntervalSinceNow: 3600)
         talk.summary =
 			"""
 			L’égalité…vaste sujet n’est ce pas ? 

--- a/Mixit/View/TalkDetail.swift
+++ b/Mixit/View/TalkDetail.swift
@@ -35,10 +35,30 @@ struct TalkDetail: View {
 
     var body: some View {
         ScrollView {
-            VStack {
+            VStack(alignment: .leading) {
                 Text(talk.title ?? "")
-                    .font(.title)
+                    .font(.largeTitle).fontWeight(.semibold)
                     .frame(maxWidth: .infinity, alignment: .leading)
+
+                Spacer(minLength: 10)
+
+                if
+                    let language = talk.localizedLanguage,
+                    let languageEmoji = talk.emojiForLanguage,
+                    let format = talk.format
+                {
+
+                    HStack(spacing: 0) {
+                        Text(format.localizedCapitalized)
+                        Text(" • ")
+                        Text("\(languageEmoji) \(language)")
+                    }
+                    .foregroundStyle(.secondary)
+                    .font(.subheadline)
+
+                    Spacer(minLength: 20)
+                }
+
                 ForEach(talk.fetchSpeakers()) { speaker in
                     HStack {
                         if let photoURL = speaker.photoURLString {
@@ -68,11 +88,6 @@ struct TalkDetail: View {
                 }
                 Spacer(minLength: 20)
 
-                if let emoji = talk.emojiForLanguage, let format = talk.format {
-                    Text("\(emoji) \(format.localizedCapitalized)")
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                    Spacer(minLength: 6)
-                }
 				if let room = talk.room {
 					let formattedRoom = NSLocalizedString(room, tableName: "Rooms", comment: "")
 					TalkDetailItem(text: formattedRoom, systemImageName: "mappin.and.ellipse")

--- a/Mixit/View/TalkDetail.swift
+++ b/Mixit/View/TalkDetail.swift
@@ -46,14 +46,13 @@ struct TalkDetail: View {
 
                 if
                     let language = talk.localizedLanguage,
-                    let languageEmoji = talk.emojiForLanguage,
                     let format = talk.format
                 {
 
                     HStack(spacing: 0) {
                         Text(format.localizedCapitalized)
                         Text(" • ")
-                        Text("\(languageEmoji) \(language)")
+                        Text(language)
                     }
                     .foregroundStyle(.secondary)
                     .font(.subheadline)

--- a/Mixit/View/TalkDetailItem.swift
+++ b/Mixit/View/TalkDetailItem.swift
@@ -18,6 +18,7 @@ struct TalkDetailItem: View {
             Image(systemName: systemImageName)
                 .font(.title2)
                 .foregroundStyle(imageColor)
+                .padding(.horizontal, 6)
             Text(text)
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/Mixit/View/TalkDetailItem.swift
+++ b/Mixit/View/TalkDetailItem.swift
@@ -11,10 +11,13 @@ import SwiftUI
 struct TalkDetailItem: View {
     var text: String
     var systemImageName: String
+    var imageColor: Color
 
     var body: some View {
         HStack {
             Image(systemName: systemImageName)
+                .font(.title2)
+                .foregroundStyle(imageColor)
             Text(text)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -24,6 +27,7 @@ struct TalkDetailItem: View {
 
 struct TalkDetailItem_Previews: PreviewProvider {
     static var previews: some View {
-        TalkDetailItem(text: "Music", systemImageName: "opticaldisc")
+        TalkDetailItem(text: "Lovelace Amphitheater", systemImageName: "mappin.circle.fill", imageColor: .red)
+            .frame(maxWidth: 150)
     }
 }

--- a/Mixit/View/TalkRow.swift
+++ b/Mixit/View/TalkRow.swift
@@ -19,6 +19,7 @@ struct TalkRow: View {
             var text = ""
 
             if let startDate = talk.startDate, let endDate = talk.endDate {
+                // TODO: Move date formatter initialization to be shared across rows
                 let formatter = DateIntervalFormatter()
                 formatter.dateStyle = .none
                 formatter.timeStyle = .short
@@ -39,8 +40,10 @@ struct TalkRow: View {
         HStack {
             VStack(alignment: .leading, spacing: 8) {
                 Spacer(minLength: 2)
-                Text(talk.title ?? "")
-                    .font(.body.bold())
+                if let title = talk.title {
+                    Text(title)
+                        .font(.headline)
+                }
 
                 HStack(spacing: 0) {
                     if let format = talk.format {
@@ -74,14 +77,29 @@ struct TalkRow_Previews: PreviewProvider {
         talk.language = "fr"
         talk.format = "Keynote"
         talk.room = "AMPHI2"
-        talk.startDate = Date()
-        talk.endDate = Date().addingTimeInterval(3600)
+        talk.startDate = Date.now
+        talk.endDate = Date(timeIntervalSinceNow: 3600)
+        return talk
+    }()
+    static let talkFav: Talk = {
+        let talk = Talk(context: inMemory.container.viewContext)
+        talk.identifier = "2"
+        talk.title = "Second Talk"
+        talk.language = "en"
+        talk.format = "Keynote"
+        talk.room = "AMPHI2"
+        talk.startDate = Date.now
+        talk.endDate = Date(timeIntervalSinceNow: 3600)
+        talk.isFavorited = true
         return talk
     }()
 
     static var previews: some View {
         Group {
-            TalkRow(talk: talk)
+            List {
+                TalkRow(talk: talk)
+                TalkRow(talk: talkFav)
+            }
         }
         .previewLayout(.fixed(width: 300, height: 70))
     }

--- a/Mixit/View/TalkRow.swift
+++ b/Mixit/View/TalkRow.swift
@@ -17,20 +17,18 @@ struct TalkRow: View {
     var subtitle: String {
         get {
             var text = ""
-            if let emoji = talk.emojiForLanguage {
-                text += emoji + " "
-            }
-
-            if let format = talk.format {
-                text += format.localizedCapitalized
-            }
 
             if let startDate = talk.startDate, let endDate = talk.endDate {
                 let formatter = DateIntervalFormatter()
                 formatter.dateStyle = .none
                 formatter.timeStyle = .short
                 let dateString = formatter.string(from: startDate, to: endDate)
-                text += ", " + dateString
+                text += " • " + dateString
+            }
+
+            if let room = talk.room {
+                let formattedRoom = NSLocalizedString(room, tableName: "Rooms", comment: "")
+                text += " • " + formattedRoom
             }
 
             return text
@@ -42,9 +40,23 @@ struct TalkRow: View {
             VStack(alignment: .leading, spacing: 8) {
                 Spacer(minLength: 2)
                 Text(talk.title ?? "")
-                    .font(.body)
-                Text(subtitle)
-                    .font(.caption)
+                    .font(.body.bold())
+
+                HStack(spacing: 0) {
+                    if let emoji = talk.emojiForLanguage {
+                        Text(emoji + " ")
+                    }
+
+                    if let format = talk.format {
+                        Text(format.localizedCapitalized)
+                            .bold()
+                    }
+
+                    Text(subtitle)
+                }
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
                 Spacer(minLength: 2)
             }
             Spacer()
@@ -65,6 +77,7 @@ struct TalkRow_Previews: PreviewProvider {
         talk.title = "First Talk"
         talk.language = "fr"
         talk.format = "Keynote"
+        talk.room = "AMPHI2"
         talk.startDate = Date()
         talk.endDate = Date().addingTimeInterval(3600)
         return talk

--- a/Mixit/View/TalkRow.swift
+++ b/Mixit/View/TalkRow.swift
@@ -9,21 +9,30 @@
 import SwiftUI
 
 struct TalkRow: View {
+    let dateFormatter: DateIntervalFormatter
+
+    static func defaultDateFormatter() -> DateIntervalFormatter {
+        let formatter = DateIntervalFormatter()
+        formatter.dateStyle = .none
+        formatter.timeStyle = .short
+        return formatter
+    }
+
     @ObservedObject var talk: Talk
 
     // When next year schedule isn’t available yet, we keep all talks “active”
     let isInMaintenanceModeInBetweenEditions = false
 
-    var subtitle: String {
+    var subtitle: LocalizedStringKey {
         get {
             var text = ""
 
+            if let format = talk.format {
+                text += "**" + format.localizedCapitalized + "**"
+            }
+
             if let startDate = talk.startDate, let endDate = talk.endDate {
-                // TODO: Move date formatter initialization to be shared across rows
-                let formatter = DateIntervalFormatter()
-                formatter.dateStyle = .none
-                formatter.timeStyle = .short
-                let dateString = formatter.string(from: startDate, to: endDate)
+                let dateString = dateFormatter.string(from: startDate, to: endDate)
                 text += " • " + dateString
             }
 
@@ -32,7 +41,7 @@ struct TalkRow: View {
                 text += " • " + formattedRoom
             }
 
-            return text
+            return LocalizedStringKey(text)
         }
     }
 
@@ -45,16 +54,9 @@ struct TalkRow: View {
                         .font(.headline)
                 }
 
-                HStack(spacing: 0) {
-                    if let format = talk.format {
-                        Text(format.localizedCapitalized)
-                            .bold()
-                    }
-
-                    Text(subtitle)
-                }
-                .font(.caption)
-                .foregroundStyle(.secondary)
+                Text(subtitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
 
                 Spacer(minLength: 2)
             }
@@ -97,8 +99,8 @@ struct TalkRow_Previews: PreviewProvider {
     static var previews: some View {
         Group {
             List {
-                TalkRow(talk: talk)
-                TalkRow(talk: talkFav)
+                TalkRow(dateFormatter: TalkRow.defaultDateFormatter(), talk: talk)
+                TalkRow(dateFormatter: TalkRow.defaultDateFormatter(), talk: talkFav)
             }
         }
         .previewLayout(.fixed(width: 300, height: 70))

--- a/Mixit/View/TalkRow.swift
+++ b/Mixit/View/TalkRow.swift
@@ -59,7 +59,7 @@ struct TalkRow: View {
                 Spacer(minLength: 2)
             }
             Spacer()
-            if talk.favorited?.boolValue ?? false {
+            if talk.isFavorited {
                 Image(systemName: "star.fill")
                     .foregroundColor(.orange)
             }

--- a/Mixit/View/TalkRow.swift
+++ b/Mixit/View/TalkRow.swift
@@ -43,10 +43,6 @@ struct TalkRow: View {
                     .font(.body.bold())
 
                 HStack(spacing: 0) {
-                    if let emoji = talk.emojiForLanguage {
-                        Text(emoji + " ")
-                    }
-
                     if let format = talk.format {
                         Text(format.localizedCapitalized)
                             .bold()

--- a/Mixit/fr.lproj/Localizable.strings
+++ b/Mixit/fr.lproj/Localizable.strings
@@ -20,6 +20,9 @@
 "Please allow calendar access in Settings." = "Veuillez autoriser l’accès au calendrier dans les Réglages.";
 "OK" = "OK";
 
+"French" = "Français";
+"English" = "Anglais";
+
 // About
 
 "About MiXiT" = "À propos de MiXiT";


### PR DESCRIPTION
This PR tweaks many aspects of the layout and presentation of the talk details screen. (and also the talk list, to some extent)

These are obviously proposals—I'm totally open to tweaking or outright removing any part that's not to your liking. The changes are split across a few commits, with descriptions of exactly what changed in each.

The main goal was to make the important, timely info more prominent, easier to find.
On the talk details screen, this mainly meant highlighting the practical info: when is the talk happening, and where? The rest of the info is grouped above (in a word, what's the talk?) and below (in-depth info about the contents)

Of note, I'm using a lot of magic numbers here; but once this PR is complete (or discarded, haha) I'll happily work some `@ScaledMetric` into all this to make the app play nicely with Dynamic Type.

As a preview, here are before/after screenshots:

| Current  | PR |
| ------------- | ------------- |
|  ![Simulator Screenshot - iPhone 16 Pro - 2025-02-21 at 22 36 26](https://github.com/user-attachments/assets/7e62b628-542c-4db3-b254-e540716c0cf5) | ![Simulator Screenshot - iPhone 16 Pro - 2025-02-21 at 22 33 40](https://github.com/user-attachments/assets/03449d6f-b23f-48e4-8640-c3d6f9462018) |
| ![Simulator Screenshot - iPhone 16 Pro - 2025-02-21 at 22 36 22](https://github.com/user-attachments/assets/bc15d6bb-50ee-4a42-80a2-abc4a87f4995) | ![Simulator Screenshot - iPhone 16 Pro - 2025-02-21 at 22 34 06](https://github.com/user-attachments/assets/03a5e90f-ace2-4fbf-9d39-04fd8cbfbd75) |
